### PR TITLE
Update Gulpfile.js

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -4,7 +4,7 @@ var autoprefixer = require('gulp-autoprefixer');
 
 gulp.task('css', function() {
    gulp.src('app/assets/sass/main.scss')
-       .pipe(sass())
+       .pipe(sass({errLogToConsole: true}))
        .pipe(autoprefixer('last 10 version'))
        .pipe(gulp.dest('public/css'));
 });


### PR DESCRIPTION
Output sass errors to console (to trace css syntax errors to the offending scss file and line #)
